### PR TITLE
Control panel router

### DIFF
--- a/projects/nshmp-ng-template/package-lock.json
+++ b/projects/nshmp-ng-template/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nshmp/nshmp-ng-template",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/nshmp-ng-template/package.json
+++ b/projects/nshmp-ng-template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nshmp/nshmp-ng-template",
   "schematics": "../nshmp-template-schematics/src/collection.json",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "peerDependencies": {
     "@angular/common": "^7.2.0",
     "@angular/core": "^7.2.0"

--- a/projects/nshmp-ng-template/src/lib/control-panel/control-panel.component.ts
+++ b/projects/nshmp-ng-template/src/lib/control-panel/control-panel.component.ts
@@ -22,18 +22,16 @@ export class ControlPanelComponent implements OnInit, OnDestroy {
   constructor(
       private headerControlService: HeaderControlsService,
       private nshmpService: NshmpTemplateService,
-      private controlPanelService: ControlPanelService) {
-
-    this.controlPanelService.controlPanelInit();
-  }
+      private controlPanelService: ControlPanelService) { }
 
   ngOnInit() {
-    this.screenChangeSubscription = this.nshmpService.onSreenChange()
-        .subscribe(isSmallScreen => {
-          this.showContent = !isSmallScreen;
-          this.controlPanelSubscribe();
-        });
+    this.controlPanelService.controlPanelInit();
+    this.controlPanelSubscribe();
 
+    this.screenChangeSubscription = this.nshmpService.sceenChangeObserve()
+        .subscribe(state => {
+          this.showContent = !state.matches;
+        });
   }
 
   ngOnDestroy() {
@@ -43,13 +41,13 @@ export class ControlPanelComponent implements OnInit, OnDestroy {
   }
 
   controlPanelSubscribe() {
-    this.contentSubscription = this.headerControlService.onContentChange()
+    this.contentSubscription = this.headerControlService.contentObserve()
         .subscribe(headerControls => {
           this.showContent = headerControls.showContent;
           this.showControlPanel = headerControls.showControlPanel;
         });
 
-    this.controlPanelSubscription = this.headerControlService.onControlPanelChange()
+    this.controlPanelSubscription = this.headerControlService.controlPanelObserve()
         .subscribe(headerControls => {
           this.showContent = headerControls.showContent;
           this.showControlPanel = headerControls.showControlPanel;

--- a/projects/nshmp-ng-template/src/lib/control-panel/control-panel.service.ts
+++ b/projects/nshmp-ng-template/src/lib/control-panel/control-panel.service.ts
@@ -1,23 +1,23 @@
-import { BehaviorSubject } from 'rxjs';
 import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable({providedIn: 'root'})
 export class ControlPanelService {
 
-  private controlPanel = new BehaviorSubject<boolean>(null);
+  private controlPanelInitEmitter = new BehaviorSubject<boolean>(null);
 
   /**
-   * Fires the control panel subject.
+   * Returns the control panel observable
    */
-  controlPanelInit() {
-    this.controlPanel.next(true);
+  controlPanelObserve(): Observable<boolean> {
+    return this.controlPanelInitEmitter.asObservable();
   }
 
   /**
-   * Returns the on control panel observable
+   * Fires the control panel subject
    */
-  onControlPanel() {
-    return this.controlPanel.asObservable();
+  controlPanelInit(): void {
+    this.controlPanelInitEmitter.next(true);
   }
 
 }

--- a/projects/nshmp-ng-template/src/lib/header/header-controls/header-controls.component.ts
+++ b/projects/nshmp-ng-template/src/lib/header/header-controls/header-controls.component.ts
@@ -26,8 +26,10 @@ export class HeaderControlsComponent implements OnInit, OnDestroy {
     private nshmpService: NshmpTemplateService) { }
 
   ngOnInit() {
-    this.screenChangeSubscription = this.nshmpService.onSreenChange()
-        .subscribe(isSmallScreen => this.onScreenChange(isSmallScreen));
+    this.screenChangeSubscription = this.nshmpService.sceenChangeObserve()
+        .subscribe(state => {
+          this.onScreenChange(state.matches);
+        });
   }
 
   ngOnDestroy() {

--- a/projects/nshmp-ng-template/src/lib/header/header-controls/header-controls.service.ts
+++ b/projects/nshmp-ng-template/src/lib/header/header-controls/header-controls.service.ts
@@ -9,8 +9,8 @@ import { HeaderControls } from './header-controls.model';
 @Injectable({ providedIn: 'root' })
 export class HeaderControlsService {
 
-  private controlPanelChange = new Subject<HeaderControls>();
-  private contentChange = new Subject<HeaderControls>();
+  private controlPanelEmitter = new Subject<HeaderControls>();
+  private contentEmitter = new Subject<HeaderControls>();
 
   /**
    * Send header controls to content change.
@@ -18,7 +18,7 @@ export class HeaderControlsService {
    * @param headerControls The header controls
    */
   contentChangeNext(headerControls: HeaderControls): void {
-    this.contentChange.next(headerControls);
+    this.contentEmitter.next(headerControls);
   }
 
   /**
@@ -27,21 +27,21 @@ export class HeaderControlsService {
    * @param headerControls The header controls
    */
   controlPanelNext(headerControls: HeaderControls): void {
-    this.controlPanelChange.next(headerControls);
+    this.controlPanelEmitter.next(headerControls);
   }
 
   /**
    * Returns the on content change observable.
    */
-  onContentChange(): Observable<HeaderControls> {
-    return this.contentChange.asObservable();
+  contentObserve(): Observable<HeaderControls> {
+    return this.contentEmitter.asObservable();
   }
 
   /**
    * Returns the on control panel change observable.
    */
-  onControlPanelChange(): Observable<HeaderControls> {
-    return this.controlPanelChange.asObservable();
+  controlPanelObserve(): Observable<HeaderControls> {
+    return this.controlPanelEmitter.asObservable();
   }
 
 }

--- a/projects/nshmp-ng-template/src/lib/header/header.component.html
+++ b/projects/nshmp-ng-template/src/lib/header/header.component.html
@@ -30,10 +30,8 @@
       <div class="grid-row float-right">
 
         <!-- Header controls -->
-        <ng-template ngIf="renderHeaderControls">
-          <nshmp-template-header-controls>
-          </nshmp-template-header-controls>
-        </ng-template>
+        <nshmp-template-header-controls *ngIf="renderHeaderControls">
+        </nshmp-template-header-controls>
 
         <!-- Header dropdown menu -->
         <nshmp-template-navigation class="margin-x-1"></nshmp-template-navigation>

--- a/projects/nshmp-ng-template/src/lib/header/header.component.ts
+++ b/projects/nshmp-ng-template/src/lib/header/header.component.ts
@@ -15,14 +15,14 @@ export class HeaderComponent implements OnInit, OnDestroy {
    */
   @Input() renderSearchBar: boolean;
 
-  renderHeaderControls = false;
+  @Input() renderHeaderControls = false;
 
   controlPanelSubscription: Subscription;
 
   constructor(private controlPanelService: ControlPanelService) { }
 
   ngOnInit() {
-    this.controlPanelSubscription = this.controlPanelService.onControlPanel()
+    this.controlPanelSubscription = this.controlPanelService.controlPanelObserve()
         .subscribe(renderHeaderControls => {
           this.renderHeaderControls = renderHeaderControls;
         });

--- a/projects/nshmp-ng-template/src/lib/main-page/main-page.component.ts
+++ b/projects/nshmp-ng-template/src/lib/main-page/main-page.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ControlPanelService } from '../control-panel/control-panel.service';
 import { Subscription } from 'rxjs';
+
+import { ControlPanelService } from '../control-panel/control-panel.service';
 
 @Component({
   selector: 'nshmp-template-main-page',
@@ -15,7 +16,7 @@ export class MainPageComponent implements OnInit, OnDestroy {
   constructor(private controlPanelService: ControlPanelService) { }
 
   ngOnInit() {
-    this.controlPanelSubscription = this.controlPanelService.onControlPanel()
+    this.controlPanelSubscription = this.controlPanelService.controlPanelObserve()
         .subscribe(renderControlPanel => {
           this.renderControlPanel = renderControlPanel;
         });

--- a/projects/nshmp-ng-template/src/lib/nshmp-template.service.ts
+++ b/projects/nshmp-ng-template/src/lib/nshmp-template.service.ts
@@ -1,30 +1,23 @@
 import { Injectable } from '@angular/core';
-import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { Subject, Observable } from 'rxjs';
+import { Observable } from 'rxjs';
+import { BreakpointObserver, Breakpoints, BreakpointState } from '@angular/cdk/layout';
 
 /**
- * Get screen size changes.
+ * Get screen size changes for max-width: 63.99em, USWDS desktop breakpoint.
  */
 @Injectable({
   providedIn: 'root'
 })
 export class NshmpTemplateService {
 
-  private screenChange = new Subject<boolean>();
-
-  constructor(private breakpointObserver: BreakpointObserver) {
-    this.breakpointObserver.observe(['(max-width: 63.99em)', Breakpoints.HandsetPortrait])
-        .subscribe(state => {
-          this.screenChange.next(state.matches);
-        });
-  }
+  constructor(private breakpointObserver: BreakpointObserver) {}
 
   /**
    * Returns the screen change observable.
    * Observable returns true of max-width <= 63.99 else false.
    */
-  onSreenChange(): Observable<boolean> {
-    return this.screenChange.asObservable();
+  sceenChangeObserve(): Observable<BreakpointState> {
+    return this.breakpointObserver.observe(['(max-width: 63.99em)', Breakpoints.HandsetPortrait]);
   }
 
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,5 +2,7 @@
     [navigationList]="navigationList"
     [renderGovBanner]="true"
     [renderSearchBar]="true">
-  <app-example-app></app-example-app>
+  <router-outlet></router-outlet>
 </nshmp-template>
+
+

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,14 @@ import { AppComponent } from './app.component';
 import { NshmpTemplateModule } from 'projects/nshmp-ng-template/src/public_api';
 import { ControlPanelComponent } from './example-app/control-panel/control-panel.component';
 import { ExampleAppComponent } from './example-app/example-app.component';
+import { Routes, RouterModule } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ExampleAppComponent
+  }
+];
 
 @NgModule({
   declarations: [
@@ -19,7 +27,8 @@ import { ExampleAppComponent } from './example-app/example-app.component';
     BrowserModule,
     NshmpTemplateModule,
     MatFormFieldModule,
-    MatInputModule
+    MatInputModule,
+    RouterModule.forRoot(routes)
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
* Added routing to the example app to better simulate how the template will be used
* Updated NshmpService to return `Observable<breakpointState>` to make service usable any where
* Updated control panel service method names